### PR TITLE
Added qcow2 convertion, refactored build in per-distribution targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.swp
 .DS_store
 linux.*
+alpine.*
+debian.*
+ubuntu.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.swp
 .DS_store
-
+linux.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM amd64/debian:bullseye
 LABEL com.iximiuz-project="docker-to-linux"
 RUN apt-get -y update
-RUN apt-get -y install extlinux fdisk
+RUN apt-get -y install extlinux fdisk qemu-utils
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ alpine: alpine.img
 		--privileged \
 		--cap-add SYS_ADMIN \
 		${REPO}/builder bash /os/create_image.sh
-	qemu-img convert -c $*.img -O qcow2 $*.qcow2
 
 .PHONY:
 builder:

--- a/Makefile
+++ b/Makefile
@@ -13,45 +13,21 @@ ubuntu: ubuntu.img
 .PHONY:
 alpine: alpine.img
 
-.PHONY:
-debian.tar:
-	@make DISTR="debian" linux.tar
+%.tar:
+	@echo ${COL_GRN}"[Dump $* directory structure to tar archive]"${COL_END}
+	docker build -f $*/Dockerfile -t ${REPO}/$* .
+	docker export -o $*.tar `docker run -d ${REPO}/$* /bin/true`
 
-.PHONY:
-debian.img:
-	@make DISTR="debian" linux.img
+%.dir: %.tar
+	@echo ${COL_GRN}"[Extract $* tar archive]"${COL_END}
+	mkdir $*.dir
+	tar -xvf $*.tar -C $*.dir
 
-.PHONY:
-ubuntu.tar:
-	@make DISTR="ubuntu" linux.tar
-
-.PHONY:
-ubuntu.img:
-	@make DISTR="ubuntu" linux.img
-
-.PHONY:
-alpine.tar:
-	@make DISTR="alpine" linux.tar
-
-.PHONY:
-alpine.img:
-	@make DISTR="alpine" linux.img
-
-linux.tar:
-	@echo ${COL_GRN}"[Dump ${DISTR} directory structure to tar archive]"${COL_END}
-	docker build -f ${DISTR}/Dockerfile -t ${REPO}/${DISTR} .
-	docker export -o linux.tar `docker run -d ${REPO}/${DISTR} /bin/true`
-
-linux.dir: linux.tar
-	@echo ${COL_GRN}"[Extract ${DISTR} tar archive]"${COL_END}
-	mkdir linux.dir
-	tar -xvf linux.tar -C linux.dir
-
-linux.img: builder linux.dir
-	@echo ${COL_GRN}"[Create ${DISTR} disk image]"${COL_END}
+%.img: builder %.dir
+	@echo ${COL_GRN}"[Create $* disk image]"${COL_END}
 	docker run -it \
 		-v `pwd`:/os:rw \
-		-e DISTR=${DISTR} \
+		-e DISTR=$* \
 		--privileged \
 		--cap-add SYS_ADMIN \
 		${REPO}/builder bash /os/create_image.sh

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ alpine: alpine.img
 
 %.dir: %.tar
 	@echo ${COL_GRN}"[Extract $* tar archive]"${COL_END}
-	mkdir $*.dir
+	mkdir -p $*.dir
 	tar -xvf $*.tar -C $*.dir
 
 %.img: builder %.dir
@@ -31,6 +31,7 @@ alpine: alpine.img
 		--privileged \
 		--cap-add SYS_ADMIN \
 		${REPO}/builder bash /os/create_image.sh
+	qemu-img convert -c $*.img -O qcow2 $*.qcow2
 
 .PHONY:
 builder:
@@ -49,7 +50,7 @@ builder-interactive:
 .PHONY:
 clean: clean-docker-procs clean-docker-images
 	@echo ${COL_GRN}"[Remove leftovers]"${COL_END}
-	rm -rf mnt linux.tar linux.dir linux.img linux.vdi
+	rm -rf mnt debian.* alpine.* ubuntu.*
 
 .PHONY:
 clean-docker-procs:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Try it out:
 make debian  # or ubuntu, or alpine
 
 # 2. Run it! Use username `root` and password `root` to log in.
-qemu-system-x86_64 -drive file=linux.img,index=0,media=disk,format=raw -m 4096
+qemu-system-x86_64 -drive file=debian.img,index=0,media=disk,format=raw -m 4096
+# 2. Alternate
+qemu-system-x86_64 -hda debian.qcow2 -m 512
 
 # 3. Clean up when you are done.
 make clean

--- a/create_image.sh
+++ b/create_image.sh
@@ -18,9 +18,8 @@ sfdisk /os/${DISTR}.img < /os/partition.txt
 
 echo_blue "\n[Format partition with ext4]"
 losetup -D
-
 LOOPDEVICE=$(losetup -f)
-echo_blue "[Using ${LOOPDEVICE} loop device]"
+echo -e "\n[Using ${LOOPDEVICE} loop device]"
 losetup -o $(expr 512 \* 2048) ${LOOPDEVICE} /os/${DISTR}.img
 mkfs.ext4 ${LOOPDEVICE}
 
@@ -38,5 +37,5 @@ umount /os/mnt
 losetup -D
 
 echo_blue "[Write syslinux MBR]"
-dd if=/usr/lib/syslinux/mbr/mbr.bin of=/os/linux.img bs=440 count=1 conv=notrunc
+dd if=/usr/lib/syslinux/mbr/mbr.bin of=/os/${DISTR}.img bs=440 count=1 conv=notrunc
 

--- a/create_image.sh
+++ b/create_image.sh
@@ -39,3 +39,5 @@ losetup -D
 echo_blue "[Write syslinux MBR]"
 dd if=/usr/lib/syslinux/mbr/mbr.bin of=/os/${DISTR}.img bs=440 count=1 conv=notrunc
 
+echo_blue "[Convert to qcow2]"
+qemu-img convert -c /os/${DISTR}.img -O qcow2 /os/${DISTR}.qcow2

--- a/create_image.sh
+++ b/create_image.sh
@@ -2,33 +2,41 @@
 
 set -e
 
-echo -e "[Create disk image]"
+echo_blue() {
+    local font_blue="\033[94m"
+    local font_bold="\033[1m"
+    local font_end="\033[0m"
+
+    echo -e "\n${font_blue}${font_bold}${1}${font_end}"
+}
+
+echo_blue "[Create disk image]"
 dd if=/dev/zero of=/os/${DISTR}.img bs=$(expr 1024 \* 1024 \* 1024) count=1
 
-echo -e "\n[Make partition]"
+echo_blue "[Make partition]"
 sfdisk /os/${DISTR}.img < /os/partition.txt
 
-echo -e "\n[Format partition with ext4]"
+echo_blue "\n[Format partition with ext4]"
 losetup -D
 
 LOOPDEVICE=$(losetup -f)
-echo -e "\n[Using ${LOOPDEVICE} loop device]"
+echo_blue "[Using ${LOOPDEVICE} loop device]"
 losetup -o $(expr 512 \* 2048) ${LOOPDEVICE} /os/${DISTR}.img
 mkfs.ext4 ${LOOPDEVICE}
 
-echo -e "\n[Copy ${DISTR} directory structure to partition]"
+echo_blue "[Copy ${DISTR} directory structure to partition]"
 mkdir -p /os/mnt
 mount -t auto ${LOOPDEVICE} /os/mnt/
 cp -R /os/${DISTR}.dir/. /os/mnt/
 
-echo -e "\n[Setup extlinux]"
+echo_blue "[Setup extlinux]"
 extlinux --install /os/mnt/boot/
 cp /os/${DISTR}/syslinux.cfg /os/mnt/boot/syslinux.cfg
 
-echo -e "\n[Unmount]"
+echo_blue "[Unmount]"
 umount /os/mnt
 losetup -D
 
-echo -e "\n[Write syslinux MBR]"
+echo_blue "[Write syslinux MBR]"
 dd if=/usr/lib/syslinux/mbr/mbr.bin of=/os/linux.img bs=440 count=1 conv=notrunc
 

--- a/create_image.sh
+++ b/create_image.sh
@@ -3,23 +3,23 @@
 set -e
 
 echo -e "[Create disk image]"
-dd if=/dev/zero of=/os/linux.img bs=$(expr 1024 \* 1024 \* 1024) count=1
+dd if=/dev/zero of=/os/${DISTR}.img bs=$(expr 1024 \* 1024 \* 1024) count=1
 
 echo -e "\n[Make partition]"
-sfdisk /os/linux.img < /os/partition.txt
+sfdisk /os/${DISTR}.img < /os/partition.txt
 
 echo -e "\n[Format partition with ext4]"
 losetup -D
 
 LOOPDEVICE=$(losetup -f)
 echo -e "\n[Using ${LOOPDEVICE} loop device]"
-losetup -o $(expr 512 \* 2048) ${LOOPDEVICE} /os/linux.img
+losetup -o $(expr 512 \* 2048) ${LOOPDEVICE} /os/${DISTR}.img
 mkfs.ext4 ${LOOPDEVICE}
 
-echo -e "\n[Copy linux directory structure to partition]"
+echo -e "\n[Copy ${DISTR} directory structure to partition]"
 mkdir -p /os/mnt
 mount -t auto ${LOOPDEVICE} /os/mnt/
-cp -R /os/linux.dir/. /os/mnt/
+cp -R /os/${DISTR}.dir/. /os/mnt/
 
 echo -e "\n[Setup extlinux]"
 extlinux --install /os/mnt/boot/


### PR DESCRIPTION
When I tried to run the built debian.img using qemu 3.1.0 I encounter the error
`Initialization of device ide-hd failed: Block node is read-only`.
Converting it to qcow2 solved the problem.

This MR includes:
* The convertion to qcow2
* A smaller Makefile using % and $* notation
* Built targets are now distribution-specific (not in a unique linux.img)
* create_image steps color were changed to blue to ease tracking

