### PR TITLE
Makefile: preserving original docker file owners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,9 @@ alpine: alpine.img
 
 %.dir: %.tar
 	@echo ${COL_GRN}"[Extract $* tar archive]"${COL_END}
-	mkdir -p $*.dir
-	tar -xvf $*.tar -C $*.dir
+	docker run -it \
+		-v `pwd`:/os:rw \
+		${REPO}/builder bash -c 'mkdir -p /os/$*.dir && tar -C /os/$*.dir --numeric-owner -xf /os/$*.tar'
 
 %.img: builder %.dir
 	@echo ${COL_GRN}"[Create $* disk image]"${COL_END}

--- a/create_image.sh
+++ b/create_image.sh
@@ -41,3 +41,4 @@ dd if=/usr/lib/syslinux/mbr/mbr.bin of=/os/${DISTR}.img bs=440 count=1 conv=notr
 
 echo_blue "[Convert to qcow2]"
 qemu-img convert -c /os/${DISTR}.img -O qcow2 /os/${DISTR}.qcow2
+rm -r /os/${DISTR}.dir


### PR DESCRIPTION
Performed the extraction of the tarball from the original docker container in the build docker.  
This allows calling tar as root and therefore uses the --preserve-permissions and --same-owner options by default. Using the --numeric-owner flag forces tar to use the archive's UID/GID numbers instead of names and maintains consistency with the UID/GID declared in the original docker (/etc/passwd, /etc/group).  
In the previous case the archive was extracted in user mode and the property identifiers were lost. This ultimately amounted to having a VM with all the files owned by root:root. This could be a problem in the case of package installation that generates new users and deploys folders in the system with the new users as owner.