### PR TITLE
[complement] preserving-original-docker-file-owners

### DIFF
--- a/create_image.sh
+++ b/create_image.sh
@@ -29,7 +29,7 @@ mkfs.ext4 ${LOOPDEVICE}
 echo_blue "[Copy ${DISTR} directory structure to partition]"
 mkdir -p /os/mnt
 mount -t auto ${LOOPDEVICE} /os/mnt/
-cp -R /os/${DISTR}.dir/. /os/mnt/
+cp -a /os/${DISTR}.dir/. /os/mnt/
 
 echo_blue "[Setup extlinux]"
 extlinux --install /os/mnt/boot/


### PR DESCRIPTION
Hi there,

I'm sorry, I omitted an important part of the elements allowing to achieve the preservation of rights and owners of files during the creation of the disk image of the VM.
This pull request proposal corrects this lack.

Have a good day

Paul

----

Using the -a flag instead of the -R flag when final copying the rootfs image.
The -a flag integrates the functionality of the -R flag and adds the preservation of file/folder rights and owners, as well as the correct copying of symbolic link type elements.